### PR TITLE
MacOS support and build improvements 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(roboteam_central_server
 
 target_link_libraries(roboteam_central_server
         PRIVATE stx
-        PRIVATE networking
+        PRIVATE roboteam_utils
         PRIVATE ixwebsocket
         PRIVATE roboteam_proto
         PRIVATE roboteam_utils
@@ -31,7 +31,7 @@ target_include_directories(roboteam_central_server_tests
 target_link_libraries(roboteam_central_server_tests        
         PUBLIC stx
         PUBLIC gtest
-        PUBLIC networking
+        PUBLIC roboteam_utils
         PUBLIC ixwebsocket
         PUBLIC roboteam_proto
         PUBLIC roboteam_utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.16)
 project(roboteam_central_server VERSION 0.1.0)
 
 add_executable(roboteam_central_server 
@@ -6,21 +6,16 @@ add_executable(roboteam_central_server
         src/server.cpp
         )
 
-set_target_properties(roboteam_central_server PROPERTIES
-        CMAKE_CXX_STANDARD 20
-        CMAKE_CXX_STANDARD_REQUIRED 1
-        )
-
 target_link_libraries(roboteam_central_server
-        PUBLIC stx
-        PUBLIC networking
-        PUBLIC ixwebsocket
-        PUBLIC roboteam_proto
-        PUBLIC roboteam_utils
+        PRIVATE stx
+        PRIVATE networking
+        PRIVATE ixwebsocket
+        PRIVATE roboteam_proto
+        PRIVATE roboteam_utils
         )
 
 target_include_directories(roboteam_central_server
-        PUBLIC ./include
+        PRIVATE include/
         )
 
 add_executable(roboteam_central_server_tests


### PR DESCRIPTION
This was supposed to be just a quick job of adding MacOS support, but I noticed a couple of things that could be improved with the build system.

- Refactor to use modern CMake
- Work around Qt5 issues on MacOS
- Add instructions on how to build on MacOS
- Add missing and remove redundant dependencies in README
- Add CCache install instructions to README
- Set CMake to use unity builds
- Remove unused CMake files (cotire was included but not actually used)
  - Use modern CMake features to speed up build times
- Recommend and set default build system to Ninja
- Use newer method of fetching/discovering dependencies
   - Remove unnecessary third party git submodules 
- Change structure of some roboteam repositories (e.g. where full CMake projects were nested in the `include/` directory)


Only meant to be merged together with corresponding PRs in other repos.