### PR TITLE
Fix the code style of all roboteam files

### DIFF
--- a/include/central_utils.hpp
+++ b/include/central_utils.hpp
@@ -4,15 +4,15 @@
 #include <stx/panic.h>
 
 namespace rtt::central::utils {
-    template <typename T>
-    std::string proto_to_string(T const& data) {
-        std::string out;
-        if (data.SerializeToString(&out)) {
-            return out;
-        }
-        stx::panic("`proto_to_string` received `data`, but `data` was not serializable.");
-        return "";
+template <typename T>
+std::string proto_to_string(T const& data) {
+    std::string out;
+    if (data.SerializeToString(&out)) {
+        return out;
     }
+    stx::panic("`proto_to_string` received `data`, but `data` was not serializable.");
+    return "";
 }
+}  // namespace rtt::central::utils
 
 #endif

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -9,45 +9,40 @@
 #include "type_traits.hpp"
 
 namespace rtt::central {
-    template <zmqpp::socket_type ct, size_t port>
-    struct Connection {
-        zmqpp::context context;
-        zmqpp::socket socket;
+template <zmqpp::socket_type ct, size_t port>
+struct Connection {
+    zmqpp::context context;
+    zmqpp::socket socket;
 
-        Connection()
-            : socket{ context, ct } {
-            socket.bind("tcp://*:" + std::to_string(port));
-        }
+    Connection() : socket{context, ct} { socket.bind("tcp://*:" + std::to_string(port)); }
 
-        template <typename T>
-        stx::Result<T, std::string> read_next() {
-            static_assert(type_traits::is_serializable_v<T>, "T is not serializable to string in Connection::read_next()");
-            zmqpp::message msg;
-            std::string data{};
-            if (!socket.receive(msg, true)) {
-                return stx::Err(std::move(data));
-            }
-            msg >> data;
-            T object;
-            auto succ = object.ParseFromString(data);
-            if (succ) {
-                return stx::Ok(std::move(object));
-            }
+    template <typename T>
+    stx::Result<T, std::string> read_next() {
+        static_assert(type_traits::is_serializable_v<T>, "T is not serializable to string in Connection::read_next()");
+        zmqpp::message msg;
+        std::string data{};
+        if (!socket.receive(msg, true)) {
             return stx::Err(std::move(data));
         }
-
-        template <typename T>
-        void write(T const& s) {
-            static_assert(type_traits::is_serializable_v<T>, "T is not serializable to string in Connection::write()");
-            std::string out;
-            s.SerializeToString(&out);
-            socket.send(out);
+        msg >> data;
+        T object;
+        auto succ = object.ParseFromString(data);
+        if (succ) {
+            return stx::Ok(std::move(object));
         }
+        return stx::Err(std::move(data));
+    }
 
-        bool is_ok() {
-            return static_cast<bool>(socket);
-        }
-    };
+    template <typename T>
+    void write(T const& s) {
+        static_assert(type_traits::is_serializable_v<T>, "T is not serializable to string in Connection::write()");
+        std::string out;
+        s.SerializeToString(&out);
+        socket.send(out);
+    }
+
+    bool is_ok() { return static_cast<bool>(socket); }
+};
 
 }  // namespace rtt::central
 

--- a/include/interface.hpp
+++ b/include/interface.hpp
@@ -6,66 +6,61 @@
 #include "type_traits.hpp"
 
 namespace rtt::central {
-    template <size_t port>
-    struct Interface {
-        ix::WebSocketServer server{ port };
-        std::function<void(proto::UiSettings)> functor;
+template <size_t port>
+struct Interface {
+    ix::WebSocketServer server{port};
+    std::function<void(proto::UiSettings)> functor;
 
-        void run(std::function<void(proto::UiSettings)>&& functor) {
-            this->functor = functor;
-            server.setOnClientMessageCallback(
-                [this](std::shared_ptr<ix::ConnectionState> connectionState,
-                       ix::WebSocket& webSocket,
-                       const ix::WebSocketMessagePtr& msg) {
-                    switch (msg->type) {
-                        case ix::WebSocketMessageType::Open:
-                            std::cout << "New incoming interface connection: " << connectionState->getId() << " (ping: " << webSocket.getPingInterval() << ")" << std::endl;
-                            break;
-                        case ix::WebSocketMessageType::Message:
-                            handle_incoming(connectionState, webSocket, msg);
-                            break;
-                        case ix::WebSocketMessageType::Close:
-                            std::cout << "Interface connection closed" << std::endl;
-                            break;
-                        case ix::WebSocketMessageType::Error:
-                            std::cout << "Interface connection error" << std::endl;
-                            break;
-                        case ix::WebSocketMessageType::Ping:
-                        case ix::WebSocketMessageType::Pong:
-                        case ix::WebSocketMessageType::Fragment:
-                        default:
-                            break;
-                    }
-                });
-
-            server.listen();
-            server.start();
-        }
-
-        void handle_incoming(std::shared_ptr<ix::ConnectionState>, ix::WebSocket&, const ix::WebSocketMessagePtr& msg) {
-            proto::UiSettings data;
-            if (!data.ParseFromString(msg->str)) {
-                std::cerr << "Something else than proto::UiSettings has been received by central from ui" << std::endl;
-                return;
+    void run(std::function<void(proto::UiSettings)>&& functor) {
+        this->functor = functor;
+        server.setOnClientMessageCallback([this](std::shared_ptr<ix::ConnectionState> connectionState, ix::WebSocket& webSocket, const ix::WebSocketMessagePtr& msg) {
+            switch (msg->type) {
+                case ix::WebSocketMessageType::Open:
+                    std::cout << "New incoming interface connection: " << connectionState->getId() << " (ping: " << webSocket.getPingInterval() << ")" << std::endl;
+                    break;
+                case ix::WebSocketMessageType::Message:
+                    handle_incoming(connectionState, webSocket, msg);
+                    break;
+                case ix::WebSocketMessageType::Close:
+                    std::cout << "Interface connection closed" << std::endl;
+                    break;
+                case ix::WebSocketMessageType::Error:
+                    std::cout << "Interface connection error" << std::endl;
+                    break;
+                case ix::WebSocketMessageType::Ping:
+                case ix::WebSocketMessageType::Pong:
+                case ix::WebSocketMessageType::Fragment:
+                default:
+                    break;
             }
-            functor(data);
-        }
+        });
 
-        template <typename T>
-        void write(T const& s) {
-            static_assert(type_traits::is_serializable_v<T>, "T is not serializable to string in Connection::write()");
-            std::string out;
-            s.SerializeToString(&out);
-            auto clients = server.getClients();
-            for (auto const& each : clients) {
-                each->sendBinary(out);
-            }
-        }
+        server.listen();
+        server.start();
+    }
 
-        void stop() {
-            server.stop();
+    void handle_incoming(std::shared_ptr<ix::ConnectionState>, ix::WebSocket&, const ix::WebSocketMessagePtr& msg) {
+        proto::UiSettings data;
+        if (!data.ParseFromString(msg->str)) {
+            std::cerr << "Something else than proto::UiSettings has been received by central from ui" << std::endl;
+            return;
         }
-    };
+        functor(data);
+    }
+
+    template <typename T>
+    void write(T const& s) {
+        static_assert(type_traits::is_serializable_v<T>, "T is not serializable to string in Connection::write()");
+        std::string out;
+        s.SerializeToString(&out);
+        auto clients = server.getClients();
+        for (auto const& each : clients) {
+            each->sendBinary(out);
+        }
+    }
+
+    void stop() { server.stop(); }
+};
 }  // namespace rtt::central
 
 #endif

--- a/include/modulehandler.hpp
+++ b/include/modulehandler.hpp
@@ -8,54 +8,51 @@
 
 namespace rtt::central {
 
-    struct ModuleHandler {
-        ModuleHandler() = default;
-        // zmqpp::socket_type::server
-        // Client can connect using zmqpp::socket_type::client
-        // Send and read from many
-        Mutex<Connection<zmqpp::socket_type::server, 16969>> conns;
+struct ModuleHandler {
+    ModuleHandler() = default;
+    // zmqpp::socket_type::server
+    // Client can connect using zmqpp::socket_type::client
+    // Send and read from many
+    Mutex<Connection<zmqpp::socket_type::server, 16969>> conns;
 
-        Mutex<std::thread> conns_threads;
+    Mutex<std::thread> conns_threads;
 
-        Mutex<std::vector<proto::Handshake>>* _handshake_vector;
+    Mutex<std::vector<proto::Handshake>>* _handshake_vector;
 
-        ModuleHandler(Mutex<std::vector<proto::Handshake>>* handshake_vector)
-            : _handshake_vector{ handshake_vector } {
+    ModuleHandler(Mutex<std::vector<proto::Handshake>>* handshake_vector) : _handshake_vector{handshake_vector} {}
+
+    template <typename T>
+    void broadcast(T const& data) {
+        static_assert(type_traits::is_serializable_v<T>, "T is not serializable in ModuleHandler::broadcast()");
+        // if no modules are connected -> do not write
+        // as there will be no valid host.
+        if (_handshake_vector->acquire()->empty()) {
+            return;
         }
+        conns.acquire()->write(data);
+    }
 
-        template <typename T>
-        void broadcast(T const& data) {
-            static_assert(type_traits::is_serializable_v<T>, "T is not serializable in ModuleHandler::broadcast()");
-            // if no modules are connected -> do not write
-            // as there will be no valid host.
-            if (_handshake_vector->acquire()->empty()) {
-                return;
-            }
-            conns.acquire()->write(data);
-        }
-
-        void run(std::reference_wrapper<std::atomic<bool>> _run) {
-            while (_run.get().load()) {
-                conns.acquire()->read_next<proto::Handshake>().match(
-                    [this](proto::Handshake ok) {
-                        // check whether maybe this module name is already included?
-                        // if so -> drop it?
-                        // handshake received, push to _handshake_vector
-                        // Maybe change _handshake_vector to an std::unordered_map<std::string name, Handshake data> ?
-                        _handshake_vector->acquire()->emplace_back(std::move(ok));
-                    },
-                    [](std::string&& err) {
-                        if (err.size() == 0) {
-                            return;
-                        }
-                        // something else than a valid Handshake was received
-                        std::cout << "no valid handshake" <<err << std::endl;
+    void run(std::reference_wrapper<std::atomic<bool>> _run) {
+        while (_run.get().load()) {
+            conns.acquire()->read_next<proto::Handshake>().match(
+                [this](proto::Handshake ok) {
+                    // check whether maybe this module name is already included?
+                    // if so -> drop it?
+                    // handshake received, push to _handshake_vector
+                    // Maybe change _handshake_vector to an std::unordered_map<std::string name, Handshake data> ?
+                    _handshake_vector->acquire()->emplace_back(std::move(ok));
+                },
+                [](std::string&& err) {
+                    if (err.size() == 0) {
+                        return;
                     }
-                );
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-            }
+                    // something else than a valid Handshake was received
+                    std::cout << "no valid handshake" << err << std::endl;
+                });
+            std::this_thread::sleep_for(std::chrono::seconds(1));
         }
-    };
+    }
+};
 
 }  // namespace rtt::central
 

--- a/include/mutex.hpp
+++ b/include/mutex.hpp
@@ -5,65 +5,53 @@
 #include <thread>
 
 namespace rtt::central {
-    template <typename T, typename Locker>
-    class LockedData {
-        T* _data_ptr;
-        Locker locker;
+template <typename T, typename Locker>
+class LockedData {
+    T* _data_ptr;
+    Locker locker;
 
-    public:
-        /**
-         * @brief Construct a new Locked Data object
-         * 
-         * @param data Data that should be locked and accessed
-         * @param mtx Mutex to lock.
-         */
-        LockedData(T* data, std::mutex& mtx) noexcept
-            : _data_ptr{ data }, locker{ mtx } {
-        }
+   public:
+    /**
+     * @brief Construct a new Locked Data object
+     *
+     * @param data Data that should be locked and accessed
+     * @param mtx Mutex to lock.
+     */
+    LockedData(T* data, std::mutex& mtx) noexcept : _data_ptr{data}, locker{mtx} {}
 
-        LockedData(LockedData&&) = default;
-        LockedData(LockedData const&) = default;
-        LockedData& operator=(LockedData&&) = default;
-        LockedData& operator=(LockedData const&) = default;
+    LockedData(LockedData&&) = default;
+    LockedData(LockedData const&) = default;
+    LockedData& operator=(LockedData&&) = default;
+    LockedData& operator=(LockedData const&) = default;
 
-        ~LockedData() = default;  // just drop locker and _data_ptr
+    ~LockedData() = default;  // just drop locker and _data_ptr
 
-        /**
-         * @brief Operator overloads for ease of access
-         */
-        T* operator->() {
-            return get();
-        }
+    /**
+     * @brief Operator overloads for ease of access
+     */
+    T* operator->() { return get(); }
 
-        T& operator*() {
-            return *get();
-        }
+    T& operator*() { return *get(); }
 
-        T* get() {
-            return _data_ptr;
-        }
-    };
+    T* get() { return _data_ptr; }
+};
 
-    template <typename T, typename Locker = std::lock_guard<std::mutex>>
-    class Mutex {
-        T _internal_data;
-        std::mutex _internal_mutex;
+template <typename T, typename Locker = std::lock_guard<std::mutex>>
+class Mutex {
+    T _internal_data;
+    std::mutex _internal_mutex;
 
-    public:
-        Mutex(T&& data) noexcept
-            : _internal_data{ std::forward<T>(data) } {
-        }
+   public:
+    Mutex(T&& data) noexcept : _internal_data{std::forward<T>(data)} {}
 
-        Mutex() = default;
-        Mutex(Mutex&&) = default;
-        Mutex(Mutex const&) = default;
-        Mutex& operator=(Mutex&&) = default;
-        Mutex& operator=(Mutex const&) = default;
+    Mutex() = default;
+    Mutex(Mutex&&) = default;
+    Mutex(Mutex const&) = default;
+    Mutex& operator=(Mutex&&) = default;
+    Mutex& operator=(Mutex const&) = default;
 
-        LockedData<T, Locker> acquire() noexcept {
-            return LockedData<T, Locker>{ &_internal_data, _internal_mutex };
-        }
-    };
+    LockedData<T, Locker> acquire() noexcept { return LockedData<T, Locker>{&_internal_data, _internal_mutex}; }
+};
 }  // namespace rtt::central
 
 #endif

--- a/include/type_traits.hpp
+++ b/include/type_traits.hpp
@@ -1,16 +1,15 @@
 #ifndef __TYPE_TRAITS_HPP__
 #define __TYPE_TRAITS_HPP__
 
-#include <type_traits>
 #include <experimental/type_traits>
+#include <type_traits>
 
 namespace rtt::central::type_traits {
-    template<class T>
-    using has_serializable = 
-        decltype(std::declval<T&>().SerializeToString(std::declval<std::string*>()));
+template <class T>
+using has_serializable = decltype(std::declval<T&>().SerializeToString(std::declval<std::string*>()));
 
-    template <typename T>
-    constexpr static inline bool is_serializable_v = std::experimental::is_detected_exact_v<bool, has_serializable, T>;
+template <typename T>
+constexpr static inline bool is_serializable_v = std::experimental::is_detected_exact_v<bool, has_serializable, T>;
 }  // namespace rtt::central::type_traits
 
 #endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,80 +1,68 @@
 #include "server.hpp"
+
 #include <roboteam_utils/Time.h>
 
 namespace rtt::central {
 
-    Server::Server()
-        : modules{ &this->module_handshakes } {
-    }
+Server::Server() : modules{&this->module_handshakes} {}
 
-    void Server::handle_roboteam_ai() {
-        // read incoming data and forward to modules.
-        Time last_interface_sent_time = Time::now() - Time(1.0);
-        while (_run.load()) {
-            //TODO: don't spam AI with settings
-            auto ai = roboteam_ai.acquire();
-            Time now = Time::now(); //TODO: prevent spamming system calls
-            if (current_settings.acquire()->is_some() && now > last_interface_sent_time + Time(1.0)) {
-              last_interface_sent_time = now;
-              auto setting_message = current_settings.acquire()->clone();
-              ai->write(std::move(setting_message).unwrap());
-            }
-
-            ai->read_next<proto::ModuleState>()
-                .match(
-                    [this](proto::ModuleState&& ok) { this->handle_ai_state(ok); },
-                    [](std::string&& err) {
-                        if (err.size()) {
-                            std::cout << "Error packet received: " << std::endl;
-                            std::cout << err << std::endl;
-                     } });
+void Server::handle_roboteam_ai() {
+    // read incoming data and forward to modules.
+    Time last_interface_sent_time = Time::now() - Time(1.0);
+    while (_run.load()) {
+        // TODO: don't spam AI with settings
+        auto ai = roboteam_ai.acquire();
+        Time now = Time::now();  // TODO: prevent spamming system calls
+        if (current_settings.acquire()->is_some() && now > last_interface_sent_time + Time(1.0)) {
+            last_interface_sent_time = now;
+            auto setting_message = current_settings.acquire()->clone();
+            ai->write(std::move(setting_message).unwrap());
         }
+
+        ai->read_next<proto::ModuleState>().match([this](proto::ModuleState&& ok) { this->handle_ai_state(ok); },
+                                                  [](std::string&& err) {
+                                                      if (err.size()) {
+                                                          std::cout << "Error packet received: " << std::endl;
+                                                          std::cout << err << std::endl;
+                                                      }
+                                                  });
     }
+}
 
-
-    void Server::handle_ai_state(proto::ModuleState ok) {
-      //TODO: send state to interface and modules
-      auto handshakes = module_handshakes.acquire();
-      for (auto const& each : *handshakes) {
+void Server::handle_ai_state(proto::ModuleState ok) {
+    // TODO: send state to interface and modules
+    auto handshakes = module_handshakes.acquire();
+    for (auto const& each : *handshakes) {
         *ok.add_handshakes() = each;
-      }
-        // send it to the interface
-        roboteam_interface.acquire()->write(ok);
-        // forward this state to all modules.
-        //modules.broadcast(ok); //TODO: This call locks/blocks for some reason?
     }
+    // send it to the interface
+    roboteam_interface.acquire()->write(ok);
+    // forward this state to all modules.
+    // modules.broadcast(ok); //TODO: This call locks/blocks for some reason?
+}
 
-    void Server::handle_interface(proto::UiSettings data) {
+void Server::handle_interface(proto::UiSettings data) {
+    *this->current_settings.acquire() = stx::Some(std::move(data));
+    // TODO: if settingschanged or every 0.5 seconds, send settings to AI
+}
 
-      *this->current_settings.acquire() = stx::Some(std::move(data));
-        //TODO: if settingschanged or every 0.5 seconds, send settings to AI
-    }
+void Server::handle_modules() { modules.run(std::ref(this->_run)); }
 
-    void Server::handle_modules() {
-        modules.run(std::ref(this->_run));
-    }
+void Server::run() {
+    std::cout << "Constructing AI thread." << std::endl;
+    new (&ai_thread) Mutex{std::thread([this]() { this->handle_roboteam_ai(); })};
 
-    void Server::run() {
-        std::cout << "Constructing AI thread." << std::endl;
-        new (&ai_thread) Mutex{ std::thread([this]() {
-            this->handle_roboteam_ai();
-        }) };
+    roboteam_interface.acquire()->run([this](proto::UiSettings data) { handle_interface(std::move(data)); });
 
-        roboteam_interface.acquire()->run([this](proto::UiSettings data) { 
-            handle_interface(std::move(data)); 
-        });
+    std::cout << "Constructing Modules thread." << std::endl;
+    new (&module_thread) Mutex{std::thread([this]() { this->handle_modules(); })};
 
-        std::cout << "Constructing Modules thread." << std::endl;
-        new (&module_thread) Mutex{ std::thread([this]() {
-            this->handle_modules();
-        }) };
+    ai_thread.acquire()->join();
+    module_thread.acquire()->join();
+}
 
-        ai_thread.acquire()->join();
-        module_thread.acquire()->join();
-    }
-
-    void Server::stop() {
-        this->_run.store(false);
-        // roboteam_interface.acquire()->stop();
-    }
+void Server::stop() {
+    this->_run.store(false);
+    // roboteam_interface.acquire()->stop();
+}
 }  // namespace rtt::central

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv){
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/pair_test.cpp
+++ b/test/pair_test.cpp
@@ -3,7 +3,7 @@
 TEST(ServerTests, websocket_test) {
     Server s{};
 
-    std::thread t{ run_server, &s };
+    std::thread t{run_server, &s};
     sleep_ms(1000);
 
     rtt::networking::PairReceiver<16970> ai{};
@@ -40,7 +40,7 @@ TEST(ServerTests, websocket_test) {
 
 TEST(ServerTests, interface_test) {
     Server s{};
-    std::thread t{ run_server, &s };
+    std::thread t{run_server, &s};
     sleep_ms(1000);
     rtt::networking::PairReceiver<16970> ai{};
 

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -10,14 +10,12 @@
 #include "server.hpp"
 using namespace rtt::central;
 
-void run_server(Server* s) {
-    s->run();
-}
+void run_server(Server* s) { s->run(); }
 
 proto::UiSettings get_ui_settings() {
     proto::UiSettings settings;
     proto::PossibleUiValue ui_value{};
-    ui_value.set_allocated_text_value(new std::string{ "test123" });
+    ui_value.set_allocated_text_value(new std::string{"test123"});
     (*settings.mutable_ui_values())["interface_test"] = ui_value;
     return settings;
 }
@@ -28,8 +26,6 @@ proto::ModuleState get_simple_module_state() {
     hs->set_name("test");
     return ms;
 }
-void sleep_ms(int ms) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
-}
+void sleep_ms(int ms) { std::this_thread::sleep_for(std::chrono::milliseconds(ms)); }
 
 #endif


### PR DESCRIPTION
Clang-formatting style has been provided, but checks were skipped in
the past. Thus, the codebase diverted from the set clang-format settings.
The purpose of this commit is to reunify the codebase style and allow
continuous integration checks.